### PR TITLE
Change vite-github-pages-deployer action used branch to an experimental branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v3
       # - uses: oven-sh/setup-bun@v2
       - name: Deploy to Github Pages
-        uses: sondalex/vite-github-pages-deployer@add_working_directory
+        uses: skywarth/vite-github-pages-deployer@separate-dependency-to-working-dir
         id: deploy_to_pages
         with:
           package_manager: yarn 


### PR DESCRIPTION
Change the action: `vite-github-pages-deployer` used branch to another (experimental) branch.